### PR TITLE
Add support for fanmade custom parts, improve solution output printing and mark interactive solutions

### DIFF
--- a/AdventOfCSharp.AnalyzerTests/PartSolverAttributes/AoCS0013_Tests.cs
+++ b/AdventOfCSharp.AnalyzerTests/PartSolverAttributes/AoCS0013_Tests.cs
@@ -14,7 +14,7 @@ namespace AoC.Random;
 
 public class Nothing : NotProblem<int>
 {
-    [↓PartSolver]
+    [↓PartSolver(""Solver"", SolverKind = PartSolverKind.Custom)]
     public int Solver() => -1;
 }
 ";
@@ -33,25 +33,25 @@ public class Day1 : Problem<int>
     public override int SolvePart1() => -1;
     public override int SolvePart2() => -2;
 
-    [↓PartSolver]
+    [↓PartSolver(""Parameter"", SolverKind = PartSolverKind.Custom)]
     public int Parameter(int x) => x;
-    [↓PartSolver]
+    [↓PartSolver(""Generic"", SolverKind = PartSolverKind.Custom)]
     public int Generic<T>() => -1;
-    [↓PartSolver]
+    [↓PartSolver(""Void"", SolverKind = PartSolverKind.Custom)]
     public void Void() { }
 
-    [↓PartSolver]
+    [↓PartSolver(""Static"", SolverKind = PartSolverKind.Custom)]
     public static int Static() => -1;
 
-    [↓PartSolver]
+    [↓PartSolver(""ProtectedInternal"", SolverKind = PartSolverKind.Custom)]
     protected internal int ProtectedInternal() => -1;
-    [↓PartSolver]
+    [↓PartSolver(""Internal"", SolverKind = PartSolverKind.Custom)]
     internal int Internal() => -1;
-    [↓PartSolver]
+    [↓PartSolver(""Protected"", SolverKind = PartSolverKind.Custom)]
     protected int Protected() => -1;
-    [↓PartSolver]
+    [↓PartSolver(""PrivateProtected"", SolverKind = PartSolverKind.Custom)]
     private protected int PrivateProtected() => -1;
-    [↓PartSolver]
+    [↓PartSolver(""Private"", SolverKind = PartSolverKind.Custom)]
     private int Private() => -1;
 }
 ";
@@ -66,9 +66,9 @@ public class Day1 : Problem<int>
 @"
 public abstract class Problem<T1, T2> : Problem
 {
-    [PartSolver]
+    [PartSolver(""Part 1"", SolverKind = PartSolverKind.Custom)]
     public abstract T1 SolvePart1();
-    [PartSolver]
+    [PartSolver(""Part 2"", SolverKind = PartSolverKind.Custom)]
     public abstract T2 SolvePart2();
 }
 ";

--- a/AdventOfCSharp/BaseProgram.cs
+++ b/AdventOfCSharp/BaseProgram.cs
@@ -325,8 +325,29 @@ Focus on development, you lazy fucking ass
         var parts = new ProblemRunner(instance).SolveAllParts(testCase);
         WriteLine();
         foreach (var part in parts)
-            WriteLine(AnswerStringConversion.Convert(part));
+        {
+            FancyPrinting.PrintLabel(part.PartName);
+            WriteLineWithColor($" {AnswerStringConversion.Convert(part.Output)}", GetAnswerColor(instance, part.PartName));
+        }
         WriteLine();
+    }
+
+    private static ConsoleColor GetAnswerColor(Problem instance, string partName)
+    {
+        if (IsFinalDayPart2(instance, partName))
+        {
+            return IFinalDay.IsAvailable(instance.Year) switch
+            {
+                true => ConsoleColor.Green,
+                false => ConsoleColor.Red,
+            };
+        }
+
+        return ConsoleColor.Yellow;
+    }
+    private static bool IsFinalDayPart2(Problem instance, string partName)
+    {
+        return partName is "Part 2" && instance is IFinalDay;
     }
 
     protected static void DisplayInlineProblemYear(int year)

--- a/AdventOfCSharp/FancyPrinting.cs
+++ b/AdventOfCSharp/FancyPrinting.cs
@@ -1,0 +1,58 @@
+﻿using System.Text.RegularExpressions;
+
+namespace AdventOfCSharp;
+
+public static class FancyPrinting
+{
+    private static readonly Regex partPattern = new(@"Part (\d*)$");
+
+    public static void PrintLabel(string partName)
+    {
+        GetPartLabelPrinter(partName)(partName);
+    }
+    public static PartLabelPrinter GetPartLabelPrinter(string partName)
+    {
+        var match = partPattern.Match(partName);
+
+        if (match.Success)
+            return PrintPartLabel;
+
+        return PrintCustomPartLabel;
+    }
+
+    public delegate void PartLabelPrinter(string partName);
+
+    public static void PrintCustomPartLabel(string partName)
+    {
+        ConsoleUtilities.WriteWithColor(partName.PadLeft(20), ConsoleColor.Cyan);
+        Console.Write(':');
+    }
+    public static void PrintPartLabel(string partName)
+    {
+        int part = GetOfficialPartIndex(partName);
+        var partString = part.ToString();
+        var partPrefix = partName[..^partString.Length];
+        ConsoleUtilities.WriteWithColor(partPrefix.PadLeft(20 - partString.Length), ConsoleColor.Cyan);
+        ConsoleUtilities.WriteWithColor(partString, GetPartColor(part));
+        Console.Write(':');
+    }
+
+    private static int GetOfficialPartIndex(string partName)
+    {
+        // Part indices >= 10 aren't supposed to exist
+        return partName.Last().GetNumericValueInteger();
+    }
+
+    private static ConsoleColor GetPartColor(int part) => part switch
+    {
+        1 => ConsoleColor.DarkGray,
+        2 => ConsoleColor.DarkYellow,
+
+        // This will catch some users off-guard
+        3 => ConsoleColor.DarkRed,
+        > 3 => ConsoleColor.Magenta,
+
+        // "Where did my 0 go?"
+        _ => Console.ForegroundColor,
+    };
+}

--- a/AdventOfCSharp/FinalDay.cs
+++ b/AdventOfCSharp/FinalDay.cs
@@ -1,13 +1,25 @@
 ﻿namespace AdventOfCSharp;
 
-public abstract class FinalDay<T> : Problem<T, string>
+public interface IFinalDay
+{
+    internal const string LockedPartString = "You have not collected all 49* to unlock this part!";
+
+    private protected static string GetCompletionCongratulationString(int year) => $"Congratulations on completing all of AoC {year}!";
+
+    public static bool IsAvailable(int year)
+    {
+        return ProblemsIndex.Instance.DetermineLastDayPart2Availability(year);
+    }
+}
+
+public abstract class FinalDay<T> : Problem<T, string>, IFinalDay
     where T : notnull
 {
     public sealed override string SolvePart2()
     {
-        if (!ProblemsIndex.Instance.DetermineLastDayPart2Availability(Year))
-            return "You have not collected all 49* to unlock this part!";
+        if (!IFinalDay.IsAvailable(Year))
+            return IFinalDay.LockedPartString;
 
-        return $"Congratulations on completing all of AoC {Year}!";
+        return IFinalDay.GetCompletionCongratulationString(Year);
     }
 }

--- a/AdventOfCSharp/PartSolutionStatus.cs
+++ b/AdventOfCSharp/PartSolutionStatus.cs
@@ -17,7 +17,7 @@ public enum PartSolutionStatus
 
     /// <summary>
     /// Represents a free star that is not currently available.
-    /// This is (so far) only the case for D25P2 if not all other 49 star have been claimed.
+    /// This is (so far) only the case for D25P2 if not all other 49 stars have been claimed.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     UnavailableFreeStar,
@@ -28,6 +28,17 @@ public enum PartSolutionStatus
     /// Consider using <seealso cref="WIP"/> if the part has not been solved in a previous timeframe.
     /// </remarks>
     Refactoring,
+
+    /// <summary>
+    /// The solution is interactive with the user. In other words, the solution does not solve the entire part on its own,
+    /// as it requires some form of interaction with the user, whose input is retrieved.
+    /// </summary>
+    /// <remarks>
+    /// Interactive solutions are considered complete, and the star is considered acclaimed.
+    /// When attempting to refactor the interactive solution into an automated one, consider using <seealso cref="Refactoring"/>.<br/>
+    /// Live execution time printing is automatically disabled for interactive solutions.
+    /// </remarks>
+    Interactive,
 }
 
 public static class PartSolutionStatusExtensions

--- a/AdventOfCSharp/PartSolverAttribute.cs
+++ b/AdventOfCSharp/PartSolverAttribute.cs
@@ -2,4 +2,28 @@
 
 /// <summary>Denotes that a method solves a problem's part. It applies to standard part 1 and 2 solvers, as well as custom part or easter egg solvers.</summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-public sealed class PartSolverAttribute : Attribute { }
+public sealed class PartSolverAttribute : Attribute
+{
+    /// <summary>The name of the part.</summary>
+    public string PartName { get; }
+
+    /// <summary>Gets the <seealso cref="PartSolverKind"/> for this part solver.</summary>
+    public PartSolverKind SolverKind { get; init; } = PartSolverKind.Official;
+
+    public PartSolverAttribute(string partName)
+    {
+        PartName = partName;
+    }
+}
+
+/// <summary>Represents the part solver kind.</summary>
+public enum PartSolverKind
+{
+    /// <summary>Represents a solver for an official part (part 1 or 2).</summary>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    Official,
+    /// <summary>Represents a solver for a custom part (usually fanmade "part 3").</summary>
+    Custom,
+    /// <summary>Represents a solver for an easter egg.</summary>
+    EasterEgg,
+}

--- a/AdventOfCSharp/Problem.cs
+++ b/AdventOfCSharp/Problem.cs
@@ -274,20 +274,9 @@ public abstract class Problem<T1, T2> : Problem
     where T1 : notnull
     where T2 : notnull
 {
-    public T1 RunPart1()
-    {
-        EnsureLoadedState();
-        return SolvePart1();
-    }
-    public T2 RunPart2()
-    {
-        EnsureLoadedState();
-        return SolvePart2();
-    }
-
-    [PartSolver]
+    [PartSolver("Part 1")]
     public abstract T1 SolvePart1();
-    [PartSolver]
+    [PartSolver("Part 2")]
     public abstract T2 SolvePart2();
 }
 

--- a/AdventOfCSharp/ProblemRunner.cs
+++ b/AdventOfCSharp/ProblemRunner.cs
@@ -28,10 +28,10 @@ public sealed class ProblemRunner
     public static ProblemRunner? ForProblem(int year, int day) => ForInstance(ProblemsIndex.Instance[year, day].InitializeInstance());
 
     // Too many displayExecutionTimes parameters; could be handled from some property
-    public object[] SolveAllParts(bool displayExecutionTimes = true) => SolveAllParts(0, displayExecutionTimes);
-    public object[] SolveAllParts(int testCase, bool displayExecutionTimes = true)
+    public PartSolutionOutputDictionary SolveAllParts(bool displayExecutionTimes = true) => SolveAllParts(0, displayExecutionTimes);
+    public PartSolutionOutputDictionary SolveAllParts(int testCase, bool displayExecutionTimes = true)
     {
-        var methods = Problem.GetType().GetMethods().Where(m => m.Name.StartsWith(SolvePartMethodPrefix)).ToArray();
+        var methods = Problem.GetType().GetMethods().Where(m => m.HasCustomAttribute<PartSolverAttribute>()).ToArray();
         return SolveParts(testCase, methods, displayExecutionTimes);
     }
 
@@ -39,7 +39,7 @@ public sealed class ProblemRunner
     public object SolvePart(int part, int testCase, bool displayExecutionTimes = true)
     {
         var methods = new[] { Problem.GetType().GetMethod(SolvePartMethodName(part))! };
-        return SolveParts(testCase, methods, displayExecutionTimes)[0];
+        return SolveParts(testCase, methods, displayExecutionTimes).GetPartOutput(part)!;
     }
 
     public bool FullyValidateAllTestCases(bool displayExecutionTimes = true)
@@ -77,26 +77,28 @@ public sealed class ProblemRunner
     private static string SolvePartMethodName(int part) => ExecutePartMethodName(SolvePartMethodPrefix, part);
     private static string ExecutePartMethodName(string prefix, int part) => $"{prefix}{part}";
 
-    private object[] SolveParts(int testCase, MethodInfo[] solutionMethods, bool displayExecutionTimes)
+    private PartSolutionOutputDictionary SolveParts(int testCase, MethodInfo[] solutionMethods, bool displayExecutionTimes)
     {
-        var result = new object[solutionMethods.Length];
+        var result = new PartSolutionOutputDictionary();
 
         Problem.CurrentTestCase = testCase;
 
         var stateLoader = Problem.GetType().GetMethod("LoadState", BindingFlags.NonPublic | BindingFlags.Instance)!;
         bool inputPrints = MethodPrints(stateLoader);
-        RunDisplayExecutionTimes(displayExecutionTimes, inputPrints, 0, "Input", PrintCustomPartExecutionTime, Problem.EnsureLoadedState);
+        RunDisplayExecutionTimes(displayExecutionTimes, inputPrints, "Input", FancyPrinting.PrintCustomPartLabel, Problem.EnsureLoadedState);
 
-        for (int i = 0; i < result.Length; i++)
+        for (int i = 0; i < solutionMethods.Length; i++)
         {
             var method = solutionMethods[i];
             bool prints = MethodPrints(method);
-            int part = method.Name.Last().GetNumericValueInteger();
-            RunDisplayExecutionTimes(displayExecutionTimes, prints, part, null!, PrintPartExecutionTime, SolveAssignResult);
+            var partName = method.GetCustomAttribute<PartSolverAttribute>()!.PartName;
+
+            RunDisplayExecutionTimes(displayExecutionTimes, prints, partName, FancyPrinting.GetPartLabelPrinter(partName), SolveAssignResult);
 
             void SolveAssignResult()
             {
-                result[i] = solutionMethods[i].Invoke(Problem, null)!;
+                var output = solutionMethods[i].Invoke(Problem, null)!;
+                result.Add(partName, output);
             }
         }
         return result;
@@ -104,10 +106,11 @@ public sealed class ProblemRunner
 
     private static bool MethodPrints(MethodInfo method)
     {
-        return method.HasCustomAttribute<PrintsToConsoleAttribute>();
+        return method.HasCustomAttribute<PrintsToConsoleAttribute>()
+            || method.GetCustomAttribute<PartSolutionAttribute>() is { Status: PartSolutionStatus.Interactive };
     }
 
-    private static void RunDisplayExecutionTimes(bool displayExecutionTimes, bool prints, int part, string partName, ExecutionTimeLabelPrinter printer, Action runner)
+    private static void RunDisplayExecutionTimes(bool displayExecutionTimes, bool prints, string partName, FancyPrinting.PartLabelPrinter printer, Action runner)
     {
         bool defaultLivePrintingSetting = ExecutionTimePrinting.EnableLivePrinting;
         if (prints)
@@ -115,7 +118,7 @@ public sealed class ProblemRunner
 
         if (displayExecutionTimes)
         {
-            printer(part, partName);
+            printer(partName);
             ExecutionTimePrinting.BeginExecutionMeasuring();
         }
 
@@ -128,32 +131,67 @@ public sealed class ProblemRunner
 
         ExecutionTimePrinting.EnableLivePrinting = defaultLivePrintingSetting;
     }
+}
 
-    private delegate void ExecutionTimeLabelPrinter(int part, string partName);
+public sealed class PartSolutionOutputDictionary : IEnumerable<PartSolutionOutputEntry>
+{
+    private readonly Dictionary<string, object> dictionary = new();
 
-    private static void PrintCustomPartExecutionTime(int part, string partName)
+    public object? Part1Output { get; private set; }
+    public object? Part2Output { get; private set; }
+
+    public PartSolutionOutputDictionary() { }
+    public PartSolutionOutputDictionary(IEnumerable<PartSolutionOutputEntry> entries)
     {
-        ConsoleUtilities.WriteWithColor(partName.PadLeft(20), ConsoleColor.Cyan);
-        Console.Write(':');
+        AddRange(entries);
     }
-    private static void PrintPartExecutionTime(int part, string partName)
+
+    public void AddRange(IEnumerable<PartSolutionOutputEntry> entries)
     {
-        var partString = part.ToString();
-        ConsoleUtilities.WriteWithColor($"Part ".PadLeft(20 - partString.Length), ConsoleColor.Cyan);
-        ConsoleUtilities.WriteWithColor(partString, GetPartColor(part));
-        Console.Write(':');
+        foreach (var entry in entries)
+            Add(entry);
+    }
+    public void Add(PartSolutionOutputEntry entry)
+    {
+        Add(entry.PartName, entry.Output);
+    }
+    public void Add(string partName, object output)
+    {
+        dictionary.Add(partName, output);
+        AssignOfficialPartResult(partName, output);
+    }
+    private void AssignOfficialPartResult(string partName, object output)
+    {
+        switch (partName)
+        {
+            case "Part 1":
+                Part1Output = output;
+                break;
+
+            case "Part 2":
+                Part2Output = output;
+                break;
+        }
     }
 
-    private static ConsoleColor GetPartColor(int part) => part switch
+    public object? GetPartOutput(int part)
     {
-        1 => ConsoleColor.DarkGray,
-        2 => ConsoleColor.DarkYellow,
+        return part switch
+        {
+            1 => Part1Output,
+            2 => Part2Output,
+            _ => null,
+        };
+    }
 
-        // This will catch some users off-guard
-        3 => ConsoleColor.DarkRed,
-        > 3 => ConsoleColor.Magenta,
+    public IEnumerator<PartSolutionOutputEntry> GetEnumerator()
+    {
+        return dictionary.Select(PartSolutionOutputEntry.FromKeyValuePair).GetEnumerator();
+    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
 
-        // "Where did my 0 go?"
-        _ => Console.ForegroundColor,
-    };
+public record struct PartSolutionOutputEntry(string PartName, object Output)
+{
+    public static PartSolutionOutputEntry FromKeyValuePair(KeyValuePair<string, object> kvp) => new(kvp.Key, kvp.Value);
 }


### PR DESCRIPTION
Closes #5
Closes #30
Closes #37
Closes #54

# Progress
- [x] Expand the `PartSolver` API
- [x] Refactor returning values from solving parts in `ProblemRunner` to a `PartSolutionOutputDictionary`
- [x] Automatically run extra custom parts on `BaseProgram`
- [x] Improve output printing
- [x] Mark solutions as interactive

## `PartSolutionOutputDictionary`
- Maps part names to the resulting values (`Dictionary<string, object>`)
- Specially contains part 1 and 2 results, while still including them in the dictionary