### PR TITLE
Remove display execution times parameters from `ProblemRunner` functions

### DIFF
--- a/AdventOfCSharp.ProblemSolutionTests/ProblemRunnerTests.cs
+++ b/AdventOfCSharp.ProblemSolutionTests/ProblemRunnerTests.cs
@@ -16,6 +16,7 @@ public class ProblemRunnerTests
     public void ValidateProblem()
     {
         var runner = ProblemRunner.ForProblem(2021, 1)!;
-        Assert.True(runner.FullyValidateAllTestCases(false));
+        runner.Options.DisplayExecutionTimes = false;
+        Assert.True(runner.FullyValidateAllTestCases());
     }
 }


### PR DESCRIPTION
Additionally, include `SolveAllOfficialParts` that were missing