### PR TITLE
Analyzer for secrets containers

### DIFF
--- a/AdventOfCSharp.AnalysisTestsBase/Resources/TestSecretsContainerBase.cs
+++ b/AdventOfCSharp.AnalysisTestsBase/Resources/TestSecretsContainerBase.cs
@@ -1,0 +1,6 @@
+﻿namespace AdventOfCSharp.AnalysisTestsBase.Resources;
+
+public abstract class TestSecretsContainerBase : ISecretsContainer
+{
+    public const string SecretsType = "Test";
+}

--- a/AdventOfCSharp.AnalyzerTests/BaseAoCSDiagnosticTests.cs
+++ b/AdventOfCSharp.AnalyzerTests/BaseAoCSDiagnosticTests.cs
@@ -1,7 +1,6 @@
 ﻿using AdventOfCSharp.AnalysisTestsBase;
 using AdventOfCSharp.AnalysisTestsBase.Verifiers;
 using Gu.Roslyn.Asserts;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoseLynn.Analyzers;
@@ -50,9 +49,6 @@ public abstract class BaseAoCSDiagnosticTests : BaseDiagnosticTests
 {
     protected ExpectedDiagnostic ExpectedDiagnostic => ExpectedDiagnostic.Create(TestedDiagnosticRule);
     protected sealed override DiagnosticDescriptorStorageBase DiagnosticDescriptorStorage => AoCSDiagnosticDescriptorStorage.Instance;
-
-    // First time using this pattern to seal overriding, special syntax sugar would be appreciated
-    public sealed override DiagnosticDescriptor TestedDiagnosticRule => base.TestedDiagnosticRule;
 
     protected sealed override UsingsProviderBase GetNewUsingsProviderInstance()
     {

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0080_Tests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0080_Tests.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
+
+[TestClass]
+public sealed class AoCS0080_Tests : SecretStringPropertyAnalyzerTests
+{
+    [TestMethod]
+    public void SecretsPatternNotMatching()
+    {
+        const string testCode =
+@"
+public sealed class SomeSecrets : TestSecretsContainerBase
+{
+    [SecretStringProperty(@""\d\w\d"", ""_test"", SecretsType)]
+    public string SomeSecrets => ↓""not matching pattern"";
+}
+";
+
+        AssertDiagnosticsWithUsings(testCode);
+    }
+    [TestMethod]
+    public void SecretsPatternMatching()
+    {
+        const string testCode =
+@"
+public sealed class SomeSecrets : TestSecretsContainerBase
+{
+    [SecretStringProperty(@""\w{5}\d{2}"", ""_testRight"", SecretsType)]
+    public string CorrectPattern => ""abcde12"";
+}
+";
+
+        ValidateCodeWithUsings(testCode);
+    }
+}

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0081_Tests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0081_Tests.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
+
+[TestClass]
+public sealed class AoCS0081_Tests : SecretStringPropertyAnalyzerTests
+{
+    [TestMethod]
+    public void WithoutSecretStringProperties()
+    {
+        const string testCode =
+@"
+public sealed class ↓NoSecrets : NoSecretsBase
+{
+    public string NotSecretA => ""nothing"";
+    public string NotSecretB => ""random"";
+    public override int Value => 5;
+}
+public abstract class NoSecretsBase : TestSecretsContainerBase
+{
+    public string NotSecretBase => ""base"";
+    public abstract int Value { get; }
+}
+";
+
+        AssertDiagnosticsWithUsings(testCode);
+    }
+}

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0082_Tests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0082_Tests.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
+
+[TestClass]
+public sealed class AoCS0082_Tests : SecretStringPropertyAnalyzerTests
+{
+    [TestMethod]
+    public void NotConstantFieldForSecretType()
+    {
+        const string testCode =
+@"
+public sealed class SomeSecrets : TestSecretsContainerBase
+{
+    [SecretStringProperty(@""\d"", ""_test"", ↓""not constant type"")]
+    public string Secret => ""1"";
+}
+";
+
+        AssertDiagnosticsWithUsings(testCode);
+    }
+}

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0083_Tests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0083_Tests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
+
+[TestClass]
+public sealed class AoCS0083_Tests : SecretStringPropertyAnalyzerTests
+{
+    [DataTestMethod]
+    [DataRow("bool")]
+    [DataRow("char")]
+    [DataRow("byte")]
+    [DataRow("short")]
+    [DataRow("int")]
+    [DataRow("long")]
+    [DataRow("sbyte")]
+    [DataRow("ushort")]
+    [DataRow("uint")]
+    [DataRow("ulong")]
+    [DataRow("float")]
+    [DataRow("double")]
+    [DataRow("decimal")]
+    public void NotStringSecretType(string type)
+    {
+        string testCode =
+$@"
+public abstract class NonNumericalSecrets : TestSecretsContainerBase
+{{
+    [SecretStringProperty(@""\d"", ""numerical"", SecretsType)]
+    public abstract ↓{type} Numerical {{ get; }}
+}}
+";
+
+        AssertDiagnosticsWithUsings(testCode);
+    }
+}

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0084_Tests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0084_Tests.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
+
+[TestClass]
+public sealed class AoCS0084_Tests : SecretStringPropertyAnalyzerTests
+{
+    [TestMethod]
+    public void NotStringSecretType()
+    {
+        string testCode =
+@"
+public class NotSecretContainer
+{
+    public const string SecretsType = ""Test"";
+
+    [↓SecretStringProperty(@""\d"", ""numerical"", SecretsType)]
+    public string Secret => ""1"";
+}
+";
+
+        AssertDiagnosticsWithUsings(testCode);
+    }
+}

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0084_Tests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/AoCS0084_Tests.cs
@@ -6,7 +6,7 @@ namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
 public sealed class AoCS0084_Tests : SecretStringPropertyAnalyzerTests
 {
     [TestMethod]
-    public void NotStringSecretType()
+    public void NotSecretsContainerType()
     {
         string testCode =
 @"
@@ -14,7 +14,7 @@ public class NotSecretContainer
 {
     public const string SecretsType = ""Test"";
 
-    [↓SecretStringProperty(@""\d"", ""numerical"", SecretsType)]
+    [↓SecretStringProperty(@""\d"", ""_test"", SecretsType)]
     public string Secret => ""1"";
 }
 ";

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/CookiesTests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/CookiesTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
+
+[TestClass]
+public sealed class CookiesTests : SecretStringPropertyAnalyzerTests
+{
+    public override DiagnosticDescriptor TestedDiagnosticRule => AoCSDiagnosticDescriptorStorage.Instance[0080];
+
+    [TestMethod]
+    public void CorrectCookies()
+    {
+        // The cookies below are random mutations of existing ones
+        // Do not attempt to use them, even if they are valid for somebody
+        const string testCode =
+@"
+[SecretsContainer]
+internal sealed class MyCookies : Cookies
+{
+    public override string GA => ""GA1.2.2949042032.1125072387"";
+    public override string Session => ""04f0b5c0e6f05ca60d05b605a05468e056b1a056c026e156f05b605e0a202c050f050023b02e023a020c99833fe45c541c7b3af6b623d95718f2f9a23ecd7629"";
+}
+";
+
+        ValidateCodeWithUsings(testCode);
+    }
+
+    [TestMethod]
+    public void IncorrectCookies()
+    {
+        // The cookies below are random mutations of existing ones
+        // Do not attempt to use them, even if they are valid for somebody
+        const string testCode =
+@"
+[SecretsContainer]
+internal sealed class MyCookies : Cookies
+{
+    public override string GA => ↓""fgjdsrignjudtsignxzudi"";
+    public override string Session => ↓""jhnbdsfgjhkgbfdsnudfjvnsjudtrignsudigndsikjugtn"";
+}
+";
+
+        AssertDiagnosticsWithUsings(testCode);
+    }
+}

--- a/AdventOfCSharp.AnalyzerTests/SecretStringProperties/SecretStringPropertyAnalyzerTests.cs
+++ b/AdventOfCSharp.AnalyzerTests/SecretStringProperties/SecretStringPropertyAnalyzerTests.cs
@@ -1,0 +1,5 @@
+﻿namespace AdventOfCSharp.Analyzers.Tests.SecretStringProperties;
+
+public abstract class SecretStringPropertyAnalyzerTests : BaseAoCSDiagnosticTests<SecretStringPropertyAnalyzer>
+{
+}

--- a/AdventOfCSharp.Analyzers/AnalyzerReleases.Shipped.md
+++ b/AdventOfCSharp.Analyzers/AnalyzerReleases.Shipped.md
@@ -33,3 +33,13 @@ AoCS0015 | Information | Warning | PartSolverAttributeAnalyzer, [Documentation](
 AoCS0016 | Validity | Error | AnswerStringConverterAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0016.md)
 AoCS0017 | Validity | Error | AnswerStringConverterAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0017.md)
 AoCS0018 | Validity | Error | AnswerStringConverterAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0018.md)
+
+## Release 1.3.1
+
+### New Rules
+
+AoCS0080 | Validity | Error | SecretStringPropertyAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0080.md)
+AoCS0081 | Design | Warning | SecretStringPropertyAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0081.md)
+AoCS0082 | Best Practice | Info | SecretStringPropertyAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0082.md)
+AoCS0083 | Validity | Error | SecretStringPropertyAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0083.md)
+AoCS0084 | Validity | Error | SecretStringPropertyAnalyzer, [Documentation](../../docs/analyzers/rules/AoCS0084.md)

--- a/AdventOfCSharp.Analyzers/AoCSDiagnosticDescriptorStorage.cs
+++ b/AdventOfCSharp.Analyzers/AoCSDiagnosticDescriptorStorage.cs
@@ -18,6 +18,7 @@ internal sealed class AoCSDiagnosticDescriptorStorage : DiagnosticDescriptorStor
     public const string DesignCategory = "Design";
     public const string InformationCategory = "Information";
     public const string ValidityCategory = "Validity";
+    public const string BestPracticeCategory = "Best Practice";
     #endregion
 
     #region Rules
@@ -59,6 +60,14 @@ internal sealed class AoCSDiagnosticDescriptorStorage : DiagnosticDescriptorStor
         CreateDiagnosticDescriptor(0016, ValidityCategory);
         CreateDiagnosticDescriptor(0017, ValidityCategory);
         CreateDiagnosticDescriptor(0018, ValidityCategory);
+
+        SetDefaultDiagnosticAnalyzer<SecretStringPropertyAnalyzer>();
+
+        CreateDiagnosticDescriptor(0080, ValidityCategory);
+        CreateDiagnosticDescriptor(0081, DesignCategory);
+        CreateDiagnosticDescriptor(0082, BestPracticeCategory);
+        CreateDiagnosticDescriptor(0083, ValidityCategory);
+        CreateDiagnosticDescriptor(0084, ValidityCategory);
     }
 
     protected override DiagnosticSeverity? GetDefaultSeverity(string category)
@@ -70,6 +79,7 @@ internal sealed class AoCSDiagnosticDescriptorStorage : DiagnosticDescriptorStor
             DesignCategory => DiagnosticSeverity.Warning,
             BrevityCategory => DiagnosticSeverity.Info,
             InformationCategory => DiagnosticSeverity.Warning,
+            BestPracticeCategory => DiagnosticSeverity.Info,
         };
     }
     #endregion

--- a/AdventOfCSharp.Analyzers/DiagnosticStringResources.Designer.cs
+++ b/AdventOfCSharp.Analyzers/DiagnosticStringResources.Designer.cs
@@ -428,14 +428,5 @@ namespace AdventOfCSharp.Analyzers {
                 return ResourceManager.GetString("AoCS0084_Title", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Secret strings cannot be a numerical type.
-        /// </summary>
-        internal static string Secret_strings_cannot_be_a_numerical_type {
-            get {
-                return ResourceManager.GetString("Secret strings cannot be a numerical type", resourceCulture);
-            }
-        }
     }
 }

--- a/AdventOfCSharp.Analyzers/DiagnosticStringResources.Designer.cs
+++ b/AdventOfCSharp.Analyzers/DiagnosticStringResources.Designer.cs
@@ -347,5 +347,95 @@ namespace AdventOfCSharp.Analyzers {
                 return ResourceManager.GetString("AoCS0018_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; {1} does not match the target pattern, please ensure the entire string is used.
+        /// </summary>
+        internal static string AoCS0080_MessageFormat {
+            get {
+                return ResourceManager.GetString("AoCS0080_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Secret string does not match the pattern.
+        /// </summary>
+        internal static string AoCS0080_Title {
+            get {
+                return ResourceManager.GetString("AoCS0080_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A non-abstract type that inherits ISecretsContainer should contain properties with the SecretStringPropertyAttribute.
+        /// </summary>
+        internal static string AoCS0081_MessageFormat {
+            get {
+                return ResourceManager.GetString("AoCS0081_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type inheriting ISecretsContainer does not contain any secret string properties.
+        /// </summary>
+        internal static string AoCS0081_Title {
+            get {
+                return ResourceManager.GetString("AoCS0081_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to It is better practice to use a constant field for the type of the secret string.
+        /// </summary>
+        internal static string AoCS0082_MessageFormat {
+            get {
+                return ResourceManager.GetString("AoCS0082_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer using a constant field for the type of the secret string.
+        /// </summary>
+        internal static string AoCS0082_Title {
+            get {
+                return ResourceManager.GetString("AoCS0082_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Numerical types are not valid for secret string properties.
+        /// </summary>
+        internal static string AoCS0083_MessageFormat {
+            get {
+                return ResourceManager.GetString("AoCS0083_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only types inheriting ISecretsContainer should contain properties with the SecretStringPropertyAttribute.
+        /// </summary>
+        internal static string AoCS0084_MessageFormat {
+            get {
+                return ResourceManager.GetString("AoCS0084_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Proprties marked with SecretStringPropertyAttribute must be contained in a type inheriting ISecretsContainer.
+        /// </summary>
+        internal static string AoCS0084_Title {
+            get {
+                return ResourceManager.GetString("AoCS0084_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Secret strings cannot be a numerical type.
+        /// </summary>
+        internal static string Secret_strings_cannot_be_a_numerical_type {
+            get {
+                return ResourceManager.GetString("Secret strings cannot be a numerical type", resourceCulture);
+            }
+        }
     }
 }

--- a/AdventOfCSharp.Analyzers/DiagnosticStringResources.resx
+++ b/AdventOfCSharp.Analyzers/DiagnosticStringResources.resx
@@ -213,4 +213,34 @@
   <data name="AoCS0018_Title" xml:space="preserve">
     <value>Some primitive types are handled by the framework</value>
   </data>
+  <data name="AoCS0080_MessageFormat" xml:space="preserve">
+    <value>'{0}' {1} does not match the target pattern, please ensure the entire string is used</value>
+  </data>
+  <data name="AoCS0080_Title" xml:space="preserve">
+    <value>Secret string does not match the pattern</value>
+  </data>
+  <data name="AoCS0081_MessageFormat" xml:space="preserve">
+    <value>A non-abstract type that inherits ISecretsContainer should contain properties with the SecretStringPropertyAttribute</value>
+  </data>
+  <data name="AoCS0081_Title" xml:space="preserve">
+    <value>Type inheriting ISecretsContainer does not contain any secret string properties</value>
+  </data>
+  <data name="AoCS0082_MessageFormat" xml:space="preserve">
+    <value>It is better practice to use a constant field for the type of the secret string</value>
+  </data>
+  <data name="AoCS0082_Title" xml:space="preserve">
+    <value>Prefer using a constant field for the type of the secret string</value>
+  </data>
+  <data name="AoCS0083_MessageFormat" xml:space="preserve">
+    <value>Numerical types are not valid for secret string properties</value>
+  </data>
+  <data name="AoCS0084_MessageFormat" xml:space="preserve">
+    <value>Only types inheriting ISecretsContainer should contain properties with the SecretStringPropertyAttribute</value>
+  </data>
+  <data name="AoCS0084_Title" xml:space="preserve">
+    <value>Proprties marked with SecretStringPropertyAttribute must be contained in a type inheriting ISecretsContainer</value>
+  </data>
+  <data name="Secret strings cannot be a numerical type" xml:space="preserve">
+    <value>Secret strings cannot be a numerical type</value>
+  </data>
 </root>

--- a/AdventOfCSharp.Analyzers/DiagnosticStringResources.resx
+++ b/AdventOfCSharp.Analyzers/DiagnosticStringResources.resx
@@ -240,7 +240,4 @@
   <data name="AoCS0084_Title" xml:space="preserve">
     <value>Proprties marked with SecretStringPropertyAttribute must be contained in a type inheriting ISecretsContainer</value>
   </data>
-  <data name="Secret strings cannot be a numerical type" xml:space="preserve">
-    <value>Secret strings cannot be a numerical type</value>
-  </data>
 </root>

--- a/AdventOfCSharp.Analyzers/Diagnostics.cs
+++ b/AdventOfCSharp.Analyzers/Diagnostics.cs
@@ -92,6 +92,33 @@ internal static class Diagnostics
         return Diagnostic.Create(Instance[0018], baseTypeSyntax.GetLocation(), typeArgument.ToString());
     }
 
+    public static Diagnostic CreateAoCS0080(LiteralExpressionSyntax secretStringLiteral, AttributeData secretStringPropertyAttributeData)
+    {
+        var attributeArguments = secretStringPropertyAttributeData.ConstructorArguments;
+        var secretStringName = attributeArguments[1].Value as string;
+        var secretStringType = attributeArguments[2].Value as string;
+
+        return Diagnostic.Create(Instance[0080], secretStringLiteral.GetLocation(), secretStringName, secretStringType);
+    }
+    public static Diagnostic CreateAoCS0081(TypeDeclarationSyntax secretsContainerDeclarationSyntax)
+    {
+        return Diagnostic.Create(Instance[0081], secretsContainerDeclarationSyntax.Identifier.GetLocation());
+    }
+    public static Diagnostic CreateAoCS0082(AttributeSyntax secretStringPropertyAttributeNode)
+    {
+        var typeArgument = secretStringPropertyAttributeNode.ArgumentList.Arguments[2];
+        return Diagnostic.Create(Instance[0082], typeArgument.GetLocation());
+    }
+    public static Diagnostic CreateAoCS0083(PropertyDeclarationSyntax secretStringPropertyDeclarationNode)
+    {
+        var typeNode = secretStringPropertyDeclarationNode.Type;
+        return Diagnostic.Create(Instance[0083], typeNode.GetLocation());
+    }
+    public static Diagnostic CreateAoCS0084(AttributeData secretStringPropertyAttribute)
+    {
+        return Diagnostic.Create(Instance[0084], secretStringPropertyAttribute.ApplicationSyntaxReference.GetSyntax().GetLocation());
+    }
+
     private static Diagnostic CreateBaseListFirstTypeDiagnostic(BaseTypeDeclarationSyntax declarationNode, int code)
     {
         return Diagnostic.Create(Instance[code], declarationNode.BaseList.Types.First().GetLocation());

--- a/AdventOfCSharp.Analyzers/KnownSymbolNames.cs
+++ b/AdventOfCSharp.Analyzers/KnownSymbolNames.cs
@@ -8,6 +8,7 @@ public static class KnownSymbolNames
     public const string PartSolutionAttribute = nameof(PartSolutionAttribute);
 
     public const string SecretsContainerAttribute = nameof(SecretsContainerAttribute);
+    public const string SecretStringPropertyAttribute = nameof(SecretStringPropertyAttribute);
 
     public const string FinalDay = nameof(FinalDay);
 

--- a/AdventOfCSharp.Analyzers/SecretStringPropertyAnalyzer.cs
+++ b/AdventOfCSharp.Analyzers/SecretStringPropertyAnalyzer.cs
@@ -118,8 +118,18 @@ public sealed class SecretStringPropertyAnalyzer : AoCSAnalyzer
     }
     private static bool IsSecretStringProperty(IPropertySymbol propertySymbol, out AttributeData secretStringAttribute)
     {
-        secretStringAttribute = propertySymbol.FirstOrDefaultAttributeNamed(KnownSymbolNames.SecretStringPropertyAttribute);
-        return secretStringAttribute is not null;
+        while (true)
+        {
+            secretStringAttribute = propertySymbol.FirstOrDefaultAttributeNamed(KnownSymbolNames.SecretStringPropertyAttribute);
+            if (secretStringAttribute is not null)
+                return true;
+
+            var overridden = propertySymbol.OverriddenProperty;
+            if (overridden is null)
+                return false;
+
+            propertySymbol = overridden;
+        }
     }
 
     private static bool MatchesExact(Regex pattern, string s)

--- a/AdventOfCSharp.Analyzers/SecretStringPropertyAnalyzer.cs
+++ b/AdventOfCSharp.Analyzers/SecretStringPropertyAnalyzer.cs
@@ -1,0 +1,154 @@
+﻿using AdventOfCSharp.Analyzers.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoseLynn;
+using RoseLynn.CSharp;
+using RoseLynn.Utilities;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AdventOfCSharp.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SecretStringPropertyAnalyzer : AoCSAnalyzer
+{
+    protected override void RegisterAnalyzers(AnalysisContext context)
+    {
+        context.RegisterTargetAttributeSyntaxNodeAction(AnalyzeSecretStringPropertyAttribute, KnownSymbolNames.SecretStringPropertyAttribute);
+        context.RegisterSyntaxNodeAction(AnalyzeSecretStringProperty, SyntaxKind.PropertyDeclaration);
+        context.RegisterSymbolAction(AnalyzeDeclarationWithoutSecretStringProperties, SymbolKind.NamedType);
+    }
+
+    private void AnalyzeDeclarationWithoutSecretStringProperties(SymbolAnalysisContext context)
+    {
+        var typeSymbol = context.Symbol as INamedTypeSymbol;
+
+        if (typeSymbol.IsAbstract)
+            return;
+
+        var isSecretsContainer = IsImportantAoCSClass(typeSymbol, KnownSymbolNames.ISecretsContainer);
+        if (!isSecretsContainer)
+            return;
+
+        var hasSecretStringProperties = typeSymbol.GetAllMembersIncludingInherited().OfType<IPropertySymbol>().Any(IsSecretStringProperty);
+
+        if (!hasSecretStringProperties)
+        {
+            var typeDeclarationNode = typeSymbol.DeclaringSyntaxReferences[0].GetSyntax() as TypeDeclarationSyntax;
+            context.ReportDiagnostic(Diagnostics.CreateAoCS0081(typeDeclarationNode));
+        }
+    }
+
+    private void AnalyzeSecretStringPropertyAttribute(SyntaxNodeAnalysisContext context)
+    {
+        var secretStringPropertyAttributeNode = context.Node as AttributeSyntax;
+        var secretTypeArgumentNode = secretStringPropertyAttributeNode.ArgumentList.Arguments[2];
+        
+        var secretTypeSymbolInfo = context.SemanticModel.GetSymbolInfo(secretTypeArgumentNode.Expression);
+        if (secretTypeSymbolInfo.Symbol is IFieldSymbol { IsConst: true })
+            return;
+        
+        context.ReportDiagnostic(Diagnostics.CreateAoCS0082(secretStringPropertyAttributeNode));
+    }
+
+    private void AnalyzeSecretStringProperty(SyntaxNodeAnalysisContext context)
+    {
+        var propertyDeclarationNode = context.Node as PropertyDeclarationSyntax;
+
+        var propertySymbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclarationNode)!;
+        if (!IsSecretStringProperty(propertySymbol, out var secretStringAttribute))
+            return;
+
+        var containingType = propertySymbol.ContainingType;
+        var hasInterface = IsImportantAoCSClass(containingType, KnownSymbolNames.ISecretsContainer);
+        if (!hasInterface)
+        {
+            context.ReportDiagnostic(Diagnostics.CreateAoCS0084(secretStringAttribute));
+        }
+
+        if (IsNumerical(propertySymbol.Type.SpecialType))
+        {
+            context.ReportDiagnostic(Diagnostics.CreateAoCS0083(propertyDeclarationNode));
+            return;
+        }
+
+        if (secretStringAttribute.ConstructorArguments[0].Value is not string pattern)
+            return;
+
+        var regex = new Regex(pattern);
+
+        var returnedExpressions = ReturnedExpressions(propertyDeclarationNode, AccessorKind.Get);
+        foreach (var expression in returnedExpressions)
+        {
+            if (expression is not LiteralExpressionSyntax literal)
+                continue;
+
+            if (literal.Token.Value is not string secretString)
+                continue;
+
+            if (!MatchesExact(regex, secretString))
+                context.ReportDiagnostic(Diagnostics.CreateAoCS0080(literal, secretStringAttribute));
+        }
+    }
+
+    private static bool IsNumerical(SpecialType specialType)
+    {
+        return specialType
+            is SpecialType.System_Int16
+            or SpecialType.System_Int32
+            or SpecialType.System_Int64
+            or SpecialType.System_UInt16
+            or SpecialType.System_UInt32
+            or SpecialType.System_UInt64
+            or SpecialType.System_Byte
+            or SpecialType.System_SByte
+            or SpecialType.System_Single
+            or SpecialType.System_Double
+            or SpecialType.System_Boolean
+            or SpecialType.System_Char
+            or SpecialType.System_Decimal;
+    }
+
+    private static bool IsSecretStringProperty(IPropertySymbol propertySymbol)
+    {
+        return IsSecretStringProperty(propertySymbol, out _);
+    }
+    private static bool IsSecretStringProperty(IPropertySymbol propertySymbol, out AttributeData secretStringAttribute)
+    {
+        secretStringAttribute = propertySymbol.FirstOrDefaultAttributeNamed(KnownSymbolNames.SecretStringPropertyAttribute);
+        return secretStringAttribute is not null;
+    }
+
+    private static bool MatchesExact(Regex pattern, string s)
+    {
+        var match = pattern.Match(s);
+        return match.Success && match.Length == s.Length;
+    }
+
+    private static IEnumerable<ExpressionSyntax> ReturnedExpressions(PropertyDeclarationSyntax property, AccessorKind accessorKind)
+    {
+        if (property.AccessorList is null)
+        {
+            if (accessorKind is AccessorKind.Get)
+            {
+                return new SingleElementCollection<ExpressionSyntax>(property.ExpressionBody.Expression);
+            }
+
+            return null;
+        }
+
+        return ReturnedExpressions(property.AccessorList.GetAccessor(accessorKind));
+    }
+    private static IEnumerable<ExpressionSyntax> ReturnedExpressions(AccessorDeclarationSyntax accessor)
+    {
+        var expressionBody = accessor.ExpressionBody;
+        if (expressionBody is not null)
+            return new SingleElementCollection<ExpressionSyntax>(expressionBody.Expression);
+
+        // TODO: Filter local methods
+        return accessor.DescendantNodes().OfType<ReturnStatementSyntax>().Select(returner => returner.Expression);
+    }
+}

--- a/AdventOfCSharp.Analyzers/Utilities/AccessorListSyntaxExtensions.cs
+++ b/AdventOfCSharp.Analyzers/Utilities/AccessorListSyntaxExtensions.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace AdventOfCSharp.Analyzers.Utilities;
+
+#nullable enable
+
+public static class AccessorListSyntaxExtensions
+{
+    public static AccessorDeclarationSyntax? GetAccessor(this AccessorListSyntax? accessorList, AccessorKind accessorKind)
+    {
+        if (accessorList is null)
+            return null;
+
+        var targetSyntaxKind = accessorKind.GetRepresentingKeywordSyntaxKind();
+
+        if (targetSyntaxKind is SyntaxKind.None)
+            return null;
+
+        foreach (var accessor in accessorList.Accessors)
+        {
+            if (accessor.Keyword.IsKind(targetSyntaxKind))
+                return accessor;
+        }
+
+        return null;
+    }
+}
+
+public enum AccessorKind
+{
+    None,
+
+    Get,
+    Set,
+    Init,
+
+    Add,
+    Remove,
+}
+
+public static class AccessorKindExtensions
+{
+    public static SyntaxKind GetRepresentingKeywordSyntaxKind(this AccessorKind kind)
+    {
+        return kind switch
+        {
+            AccessorKind.None => SyntaxKind.None,
+
+            AccessorKind.Get => SyntaxKind.GetKeyword,
+            AccessorKind.Set => SyntaxKind.SetKeyword,
+            AccessorKind.Init => SyntaxKind.InitKeyword,
+
+            AccessorKind.Add => SyntaxKind.AddKeyword,
+            AccessorKind.Remove => SyntaxKind.RemoveKeyword,
+        };
+    }
+}

--- a/AdventOfCSharp/Cookies.cs
+++ b/AdventOfCSharp/Cookies.cs
@@ -8,7 +8,14 @@ namespace AdventOfCSharp;
 /// <remarks>WARNING: Do not eat! Santa will be sad!</remarks>
 public abstract class Cookies : ISecretsContainer
 {
+    private const string gaPattern = @"GA\d\.\d\.\d{10}\.\d{10}";
+    private const string sessionPattern = @"[0-9a-f]{128}";
+
+    private const string cookieName = "cookie";
+
+    [SecretStringProperty(gaPattern, "_ga", cookieName)]
     public abstract string GA { get; }
+    [SecretStringProperty(sessionPattern, "session", cookieName)]
     public abstract string Session { get; }
 
     public void AddToDefaultRequestHeaders(HttpClient client)

--- a/AdventOfCSharp/SecretStringPropertyAttribute.cs
+++ b/AdventOfCSharp/SecretStringPropertyAttribute.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+
+namespace AdventOfCSharp;
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+public sealed class SecretStringPropertyAttribute : Attribute
+{
+    public string Pattern { get; }
+    public string Name { get; }
+    public string Type { get; }
+
+    public SecretStringPropertyAttribute(string pattern, string name, string type)
+    {
+        Pattern = pattern;
+        Name = name;
+        Type = type;
+    }
+}

--- a/docs/analyzers/rules/AoCS0080.md
+++ b/docs/analyzers/rules/AoCS0080.md
@@ -1,0 +1,25 @@
+# AoCS0080
+
+## Title
+Secret string does not match the pattern
+
+## Category
+Validity
+
+## Severity
+Error
+
+## Details
+This error is reported when the returned constant value does not match the target pattern declared for the secret string.
+
+## Example
+```csharp
+public sealed class SomeSecrets : ISecretsContainer
+{
+    public const string SecretsType = "test";
+
+    [SecretStringProperty(@"\d\w\d", "_test", SecretsType)]
+    // AoCS0080 will appear here
+    public string SomeSecrets => "not matching pattern";
+}
+```

--- a/docs/analyzers/rules/AoCS0081.md
+++ b/docs/analyzers/rules/AoCS0081.md
@@ -1,0 +1,22 @@
+# AoCS0081
+
+## Title
+Type inheriting `ISecretsContainer` does not contain any secret string properties
+
+## Category
+Design
+
+## Severity
+Warning
+
+## Details
+This warning is reported when a type that inherits `ISecretsContainer` does not contain any secret string properties.
+
+## Example
+```csharp
+// AoCS0081 will appear here
+public sealed class NoSecrets : ISecretsContainer
+{
+    public string NotSecretProperty => "base";
+}
+```

--- a/docs/analyzers/rules/AoCS0082.md
+++ b/docs/analyzers/rules/AoCS0082.md
@@ -1,0 +1,23 @@
+# AoCS0082
+
+## Title
+Prefer using a constant field for the type of the secret string
+
+## Category
+Best Practice
+
+## Severity
+Info
+
+## Details
+This warning is reported when the type of the secret string property is not a constant field
+
+## Example
+```csharp
+public sealed class SomeSecrets : ISecretsContainer
+{
+    // AoCS0082 will appear on "type"
+    [SecretStringProperty(@"\d", "_test", "type")]
+    public string Secret => "1";
+}
+```

--- a/docs/analyzers/rules/AoCS0083.md
+++ b/docs/analyzers/rules/AoCS0083.md
@@ -1,0 +1,25 @@
+# AoCS0083
+
+## Title
+Numerical types are not valid for secret string properties
+
+## Category
+Validity
+
+## Severity
+Error
+
+## Details
+This error is reported when the value type of the secret string property is a numerical one.
+
+## Example
+```csharp
+public sealed class SomeSecrets : ISecretsContainer
+{
+    public const string SecretsType = "test";
+
+    [SecretStringProperty(@"\d", "_test", SecretsType)]
+    // AoCS0083 will appear here
+    public int Secret => 1;
+}
+```

--- a/docs/analyzers/rules/AoCS0084.md
+++ b/docs/analyzers/rules/AoCS0084.md
@@ -1,0 +1,25 @@
+# AoCS0084
+
+## Title
+Proprties marked with `SecretStringPropertyAttribute` must be contained in a type inheriting `ISecretsContainer`.
+
+## Category
+Validity
+
+## Severity
+Error
+
+## Details
+This error is reported when a type that does not inherit `ISecretsContainer` contains a property marked with `SecretStringPropertyAttribute`.
+
+## Example
+```csharp
+public class NotSecretContainer
+{
+    public const string SecretsType = "Test";
+
+    // AoCS0084 will appear here
+    [SecretStringProperty(@"\d", "_test", SecretsType)]
+    public string Secret => "1";
+}
+```

--- a/docs/analyzers/rules/index.md
+++ b/docs/analyzers/rules/index.md
@@ -1,22 +1,27 @@
 # Rules
-Rule ID                 | Category    | Severity
-------------------------|-------------|---------
-[AoCS0001](AoCS0001.md) | Validity    | Error
-[AoCS0002](AoCS0002.md) | Validity    | Error
-[AoCS0003](AoCS0003.md) | Brevity     | Info
-[AoCS0004](AoCS0004.md) | Convention  | Error
-[AoCS0005](AoCS0005.md) | Convention  | Error
-[AoCS0006](AoCS0006.md) | Convention  | Error
-[AoCS0007](AoCS0007.md) | Convention  | Error
-[AoCS0008](AoCS0008.md) | Validity    | Error
-[AoCS0011](AoCS0011.md) | Design      | Warning
-[AoCS0012](AoCS0012.md) | Validity    | Error
-[AoCS0013](AoCS0013.md) | Validity    | Error
-[AoCS0014](AoCS0014.md) | Validity    | Error
-[AoCS0015](AoCS0015.md) | Information | Warning
-[AoCS0016](AoCS0016.md) | Validity    | Error
-[AoCS0017](AoCS0017.md) | Validity    | Error
-[AoCS0018](AoCS0018.md) | Validity    | Error
+Rule ID                 | Category      | Severity
+------------------------|---------------|---------
+[AoCS0001](AoCS0001.md) | Validity      | Error
+[AoCS0002](AoCS0002.md) | Validity      | Error
+[AoCS0003](AoCS0003.md) | Brevity       | Info
+[AoCS0004](AoCS0004.md) | Convention    | Error
+[AoCS0005](AoCS0005.md) | Convention    | Error
+[AoCS0006](AoCS0006.md) | Convention    | Error
+[AoCS0007](AoCS0007.md) | Convention    | Error
+[AoCS0008](AoCS0008.md) | Validity      | Error
+[AoCS0011](AoCS0011.md) | Design        | Warning
+[AoCS0012](AoCS0012.md) | Validity      | Error
+[AoCS0013](AoCS0013.md) | Validity      | Error
+[AoCS0014](AoCS0014.md) | Validity      | Error
+[AoCS0015](AoCS0015.md) | Information   | Warning
+[AoCS0016](AoCS0016.md) | Validity      | Error
+[AoCS0017](AoCS0017.md) | Validity      | Error
+[AoCS0018](AoCS0018.md) | Validity      | Error
+[AoCS0080](AoCS0080.md) | Validity      | Error
+[AoCS0081](AoCS0081.md) | Design        | Warning
+[AoCS0082](AoCS0082.md) | Best Practice | Info
+[AoCS0083](AoCS0083.md) | Validity      | Error
+[AoCS0084](AoCS0084.md) | Validity      | Error
 
 ## Discontinued Rules
 Rule ID  | Embodied Rule ID(s)


### PR DESCRIPTION
Closes #42

Implements an analyzer for secrets container types, and exposes a public API to the user for declaring their secrets.

Remaining tasks:
- [x] Add documentation for the diagnostics
- [x] Add diagnostic strings